### PR TITLE
Adding danger search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'capybara'
   gem "factory_bot_rails"
+  gem 'pry'
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       xpath (~> 3.0)
     case_transform (0.2)
       activesupport
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -88,6 +89,8 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jsonapi-renderer (0.2.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -107,6 +110,9 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.2)
     puma (3.11.3)
     rack (2.0.4)
@@ -205,8 +211,10 @@ DEPENDENCIES
   faraday
   figaro
   jbuilder (~> 2.5)
+  launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 3.7)
   rails (~> 5.1.6)
   rspec-rails

--- a/app/controllers/most_dangerous_day_controller.rb
+++ b/app/controllers/most_dangerous_day_controller.rb
@@ -1,4 +1,9 @@
 class MostDangerousDayController < ApplicationController
   def index
+    start_date = params[:start_date]
+    end_date = params[:end_date]
+    render locals: {
+      facade: MostDangerousDayFacade.new(start_date, end_date)
+    }
   end
 end

--- a/app/controllers/most_dangerous_day_controller.rb
+++ b/app/controllers/most_dangerous_day_controller.rb
@@ -2,8 +2,14 @@ class MostDangerousDayController < ApplicationController
   def index
     start_date = params[:start_date]
     end_date = params[:end_date]
-    render locals: {
-      facade: MostDangerousDayFacade.new(start_date, end_date)
-    }
+    range_length = (end_date.to_datetime - start_date.to_datetime).to_s.split('/').first.to_i
+    if range_length < 7
+        render locals: {
+          facade: MostDangerousDayFacade.new(start_date, end_date)
+        }
+      else
+        flash.notice = 'Please enter dates with a max 7 day difference'
+        redirect_to root_path
+      end
   end
 end

--- a/app/controllers/most_dangerous_day_controller.rb
+++ b/app/controllers/most_dangerous_day_controller.rb
@@ -1,8 +1,5 @@
 class MostDangerousDayController < ApplicationController
   def index
-    start_date = params[:start_date]
-    end_date = params[:end_date]
-    range_length = (end_date.to_datetime - start_date.to_datetime).to_s.split('/').first.to_i
     if range_length < 7
         render locals: {
           facade: MostDangerousDayFacade.new(start_date, end_date)
@@ -11,5 +8,19 @@ class MostDangerousDayController < ApplicationController
         flash.notice = 'Please enter dates with a max 7 day difference'
         redirect_to root_path
       end
+  end
+
+  private
+
+  def range_length
+    (end_date.to_datetime - start_date.to_datetime).to_s.split('/').first.to_i
+  end
+
+  def start_date
+    params[:start_date]
+  end
+
+  def end_date
+    params[:end_date]
   end
 end

--- a/app/facades/most_dangerous_day_facade.rb
+++ b/app/facades/most_dangerous_day_facade.rb
@@ -13,17 +13,7 @@ class MostDangerousDayFacade
   end
 
   def most_dangerous_day
-    conn = Faraday.new(url: 'https://api.nasa.gov') do |faraday|
-      faraday.adapter Faraday.default_adapter
-      faraday.params['api_key'] = ENV['NASA_KEY']
-    end
-
-    response = conn.get('/neo/rest/v1/feed') do |req|
-      req.params['start_date'] = start_date
-      req.params['end_date'] = end_date
-    end
-
-    asteroids_by_day_data = JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
+    asteroids_by_day_data = service.asteroids_by_day_data(start_date, end_date)
     days = asteroids_by_day_data.map do |day_data|
       Day.new(day_data)
     end
@@ -34,4 +24,8 @@ class MostDangerousDayFacade
   private
 
   attr_reader :start_date, :end_date
+
+  def service
+    NasaService.new
+  end
 end

--- a/app/facades/most_dangerous_day_facade.rb
+++ b/app/facades/most_dangerous_day_facade.rb
@@ -5,7 +5,7 @@ class MostDangerousDayFacade
   end
 
   def search_range
-    "#{start_date.to_s.to_datetime.strftime('%B%e, %Y')} - #{end_date.to_s.to_datetime.strftime('%B%e, %Y')}"
+    "#{start_date.to_datetime.strftime('%B%e, %Y')} - #{end_date.to_datetime.strftime('%B%e, %Y')}"
   end
 
   def asteroids_for_day
@@ -13,12 +13,12 @@ class MostDangerousDayFacade
   end
 
   def most_dangerous_day
-    asteroids_by_day_data = service.asteroids_by_day_data(start_date, end_date)
-    days = asteroids_by_day_data.map do |day_data|
+    @asteroids_by_day_data ||= service.asteroids_by_day_data(start_date, end_date)
+    @days ||= @asteroids_by_day_data.map do |day_data|
       Day.new(day_data)
     end
 
-    days.max_by{|day|  day.asteroids.length}
+    @days.max_by{|day|  day.asteroids.length}
   end
 
   private

--- a/app/facades/most_dangerous_day_facade.rb
+++ b/app/facades/most_dangerous_day_facade.rb
@@ -1,0 +1,38 @@
+class MostDangerousDayFacade
+  def initialize(start_date, end_date)
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def search_range
+    "#{start_date.to_s.to_datetime.strftime('%B%e, %Y')} - #{end_date.to_s.to_datetime.strftime('%B%e, %Y')}"
+  end
+
+  def asteroids_for_day
+    most_dangerous_day.asteroids
+  end
+
+  def most_dangerous_day
+    conn = Faraday.new(url: 'https://api.nasa.gov') do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.params['api_key'] = ENV['NASA_KEY']
+    end
+
+    response = conn.get('/neo/rest/v1/feed') do |req|
+      req.params['start_date'] = start_date
+      req.params['end_date'] = end_date
+    end
+
+    asteroids_by_day_data = JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
+
+    days = asteroids_by_day_data.map do |day_data|
+      Day.new(day_data)
+    end
+
+    days.max_by{|day|  day.asteroids.length}
+  end
+
+  private
+
+  attr_reader :start_date, :end_date
+end

--- a/app/facades/most_dangerous_day_facade.rb
+++ b/app/facades/most_dangerous_day_facade.rb
@@ -1,7 +1,7 @@
 class MostDangerousDayFacade
   def initialize(start_date, end_date)
-    @start_date = start_date
-    @end_date = end_date
+    @start_date = start_date.to_datetime.strftime('%F')
+    @end_date = end_date.to_datetime.strftime('%F')
   end
 
   def search_range
@@ -24,7 +24,6 @@ class MostDangerousDayFacade
     end
 
     asteroids_by_day_data = JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
-
     days = asteroids_by_day_data.map do |day_data|
       Day.new(day_data)
     end

--- a/app/models/asteroid.rb
+++ b/app/models/asteroid.rb
@@ -1,0 +1,8 @@
+class Asteroid
+  attr_reader :dangerous, :name, :neo_id
+  def initialize(data)
+    @dangerous = data[:is_potentially_hazardous_asteroid]
+    @name = data[:name]
+    @neo_id = data[:neo_reference_id]
+  end
+end

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -1,0 +1,13 @@
+class Day
+  attr_reader :date
+  def initialize(data)
+    @date = data.first.to_s.to_datetime.strftime('%B%e, %Y')
+    @asteroid_data = data.last
+  end
+
+  def asteroids
+    @asteroids ||= @asteroid_data.map do |data|
+      Asteroid.new(data) if data[:is_potentially_hazardous_asteroid]
+    end.compact
+  end
+end

--- a/app/services/nasa_service.rb
+++ b/app/services/nasa_service.rb
@@ -1,15 +1,22 @@
 class NasaService
   def asteroids_by_day_data(start_date, end_date)
-    conn = Faraday.new(url: 'https://api.nasa.gov') do |faraday|
-      faraday.adapter Faraday.default_adapter
-      faraday.params['api_key'] = ENV['NASA_KEY']
-    end
+    response = astroids_by_date(start_date, end_date)
+    JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
+  end
 
-    response = conn.get('/neo/rest/v1/feed') do |req|
+  private
+
+  def astroids_by_date(start_date, end_date)
+    conn.get('/neo/rest/v1/feed') do |req|
       req.params['start_date'] = start_date
       req.params['end_date'] = end_date
     end
+  end
 
-    JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
+  def conn
+    Faraday.new(url: 'https://api.nasa.gov') do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.params['api_key'] = ENV['NASA_KEY']
+    end
   end
 end

--- a/app/services/nasa_service.rb
+++ b/app/services/nasa_service.rb
@@ -1,0 +1,15 @@
+class NasaService
+  def asteroids_by_day_data(start_date, end_date)
+    conn = Faraday.new(url: 'https://api.nasa.gov') do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.params['api_key'] = ENV['NASA_KEY']
+    end
+
+    response = conn.get('/neo/rest/v1/feed') do |req|
+      req.params['start_date'] = start_date
+      req.params['end_date'] = end_date
+    end
+
+    JSON.parse(response.body, symbolize_names: true)[:near_earth_objects]
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,9 @@
           <% end %>
         </section>
       </nav>
-
+      <% flash.each do |type, msg| %>
+        <p class='<%= type %>'><%= msg %></p>
+      <% end %>
       <%= yield %>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/app/views/most_dangerous_day/index.html.erb
+++ b/app/views/most_dangerous_day/index.html.erb
@@ -1,5 +1,5 @@
 <h2>For Range:</h2>
-<p><%= facade.search_range %></p>
+<%= facade.search_range %>
 <section id='most-dangerous-day'>
   <p>Most Dangerous Day: <%= facade.most_dangerous_day.date %></p>
   <% facade.asteroids_for_day.each do |asteroid| %>

--- a/app/views/most_dangerous_day/index.html.erb
+++ b/app/views/most_dangerous_day/index.html.erb
@@ -1,0 +1,11 @@
+<h2>For Range:</h2>
+<p><%= facade.search_range %></p>
+<section id='most-dangerous-day'>
+  <p>Most Dangerous Day: <%= facade.most_dangerous_day.date %></p>
+  <% facade.asteroids_for_day.each do |asteroid| %>
+    <ul class='asteroid'>
+      <li>Name: <%= asteroid.name %></li>
+      <li>NEO Reference ID: <%= asteroid.neo_id %></li>
+    </ul>
+  <% end %>
+</section>

--- a/spec/features/most_dangerous_day/index_spec.rb
+++ b/spec/features/most_dangerous_day/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'As a visitor' do
   describe 'on the home page' do
 
     it "can search most dangerous day" do
-      visit '/'
+      visit root_path
 
       fill_in :start_date, with: "2018-01-01"
       fill_in :end_date, with: "2018-01-07"
@@ -50,6 +50,18 @@ RSpec.describe 'As a visitor' do
         expect(page).to have_content("Name: (2017 YR1)")
         expect(page).to have_content("NEO Reference ID: 3794979")
       end
+    end
+
+    it "can't search more than 7 days" do
+      visit root_path
+
+      fill_in :start_date, with: "2018-01-01"
+      fill_in :end_date, with: "2018-01-09"
+
+      click_button "Determine Most Dangerous Day"
+
+      expect(current_path).to eq(root_path)
+      expect(page).to have_content('Please enter dates with a max 7 day difference')
     end
 
   end

--- a/spec/features/most_dangerous_day/index_spec.rb
+++ b/spec/features/most_dangerous_day/index_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+#
+# As a guest user
+# When I visit "/"
+# And I enter "2018-01-01" into the start date
+# And I enter "2018-01-07" into the end date
+# And I click "Determine Most Dangerous Day"
+#
+# Then I should be on "/most_dangerous_day"
+# And I should see a heading for "Most Dangerous Day"
+# And I should see "January 1, 2018 - January 7, 2018"
+# And I should see a heading for the most dangerous day in that range "January 1, 2018"
+# And I should see 3 asteroids in that list
+#
+# And I should see "Name: (2014 KT76)"
+# And I should see "NEO Reference ID: 3672906"
+#
+# And I should see "Name: (2001 LD)"
+# And I should see "NEO Reference ID: 3078262"
+#
+# And I should see "Name: (2017 YR1)"
+# And I should see "NEO Reference ID: 3794979"
+
+RSpec.describe 'As a visitor' do
+  describe 'on the home page' do
+
+    it "can search most dangerous day" do
+      visit '/'
+      
+      fill_in :start_date, with: "2018-01-01"
+      fill_in :end_date, with: "2018-01-07"
+
+      click_button "Determine Most Dangerous Day"
+
+      expect(current_path).to eq(most_dangerous_day_path)
+
+      expect(page).to have_content("Most Dangerous Day for Range:")
+      expect(page).to have_content("January 1, 2018 - January 7, 2018")
+
+      within "#most-dangerous-day" do
+        expect(page).to have_content('Most Dangerous Day:')
+        expect(page).to have_css('.asteroid', count: 3)
+
+        within(first.('.asteroid')) do
+          expect(page).to have_content("Name: (2014 KT76)")
+          expect(page).to have_content("NEO Reference ID: 3672906")
+        end
+
+        within(second.('.asteroid')) do
+          expect(page).to have_content("Name: (2001 LD)")
+          expect(page).to have_content("NEO Reference ID: 3078262")
+        end
+
+        within(third.('.asteroid')) do
+          expect(page).to have_content("Name: (2017 YR1)")
+          expect(page).to have_content("NEO Reference ID: 3794979")
+        end
+
+      end
+    end
+
+  end
+end

--- a/spec/features/most_dangerous_day/index_spec.rb
+++ b/spec/features/most_dangerous_day/index_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'As a visitor' do
 
     it "can search most dangerous day" do
       visit '/'
-      
+
       fill_in :start_date, with: "2018-01-01"
       fill_in :end_date, with: "2018-01-07"
 
@@ -34,28 +34,21 @@ RSpec.describe 'As a visitor' do
 
       expect(current_path).to eq(most_dangerous_day_path)
 
-      expect(page).to have_content("Most Dangerous Day for Range:")
+      expect(page).to have_content("For Range:")
       expect(page).to have_content("January 1, 2018 - January 7, 2018")
 
       within "#most-dangerous-day" do
-        expect(page).to have_content('Most Dangerous Day:')
+        expect(page).to have_content('Most Dangerous Day: January 1, 2018')
         expect(page).to have_css('.asteroid', count: 3)
 
-        within(first.('.asteroid')) do
-          expect(page).to have_content("Name: (2014 KT76)")
-          expect(page).to have_content("NEO Reference ID: 3672906")
-        end
+        expect(page).to have_content("Name: (2001 LD)")
+        expect(page).to have_content("NEO Reference ID: 3078262")
 
-        within(second.('.asteroid')) do
-          expect(page).to have_content("Name: (2001 LD)")
-          expect(page).to have_content("NEO Reference ID: 3078262")
-        end
+        expect(page).to have_content("Name: (2014 KT76)")
+        expect(page).to have_content("NEO Reference ID: 3672906")
 
-        within(third.('.asteroid')) do
-          expect(page).to have_content("Name: (2017 YR1)")
-          expect(page).to have_content("NEO Reference ID: 3794979")
-        end
-
+        expect(page).to have_content("Name: (2017 YR1)")
+        expect(page).to have_content("NEO Reference ID: 3794979")
       end
     end
 


### PR DESCRIPTION
### What does this PR do?

- Adds feature spec and functionality for most dangerous day search
  - Limits search to 7 day difference max.
- Adds Nasa Service
- Adds Most Dangerous Day Facade
- Adds to Most Dangerous Day Index to show all asteroids deemed dangerous
  - Shows Name & NEO Reference ID